### PR TITLE
PSX Fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.0.2 (Unreleased)
+==================
+
+- Grouped ``rerelease`` with ``demoted_versions`` in regex
+- Decoupled revisions from versions
+- Revisions are now weighted more heavily than versions
+- Budget editions are now favoured above anything else, assuming they roll in the various revision/version changes
+- Fixed bug in GameFinder where occasionally multiple entries due to upper/lowercase could occur
+
 0.0.1 (2024-05-06)
 ==================
 

--- a/romsearch/configs/regex.yml
+++ b/romsearch/configs/regex.yml
@@ -115,7 +115,7 @@ promo:
   group: "promotional"
   search_tags: false
 
-# VERSIONS
+# VERSIONS AND REVISIONS
 version_no:
   pattern: "\\(v[\\.0-9].*?\\)"
   type: "str"
@@ -133,7 +133,6 @@ revision:
   type: "str"
   transform_pattern: "R[eE][vV][ -]([0-9A-Z].*?)?"
   transform_repl: "v\\1"
-  group: "version"
 
 # UNLICENSED
 aftermarket:
@@ -373,6 +372,10 @@ piko_interactive:
   pattern: "\\(Piko Interactive\\)"
   group: "demote_version"
 
+rerelease:
+  pattern: "\\(Rerelease\\)"
+  group: "demoted_version"
+
 reprint:
   pattern: "\\(Reprint\\)"
   group: "demoted_version"
@@ -385,6 +388,3 @@ shokai_seisanban:
 
 strictly_limited:
   pattern: "\\(Strictly Limited Games\\)"
-
-rerelease:
-  pattern: "\\(Rerelease\\)"

--- a/romsearch/modules/gamefinder.py
+++ b/romsearch/modules/gamefinder.py
@@ -186,11 +186,20 @@ class GameFinder:
             found_parent_name = get_parent_name(game_name=g,
                                                 dupe_dict=dupes,
                                                 )
-            if found_parent_name not in game_dict:
+
+            found_parent_name_lower = found_parent_name.lower()
+            game_dict_keys = [key for key in game_dict.keys()]
+            game_dict_keys_lower = [key.lower() for key in game_dict.keys()]
+
+            if found_parent_name_lower not in game_dict_keys_lower:
                 game_dict[found_parent_name] = {}
+                final_parent_name = copy.deepcopy(found_parent_name)
+            else:
+                final_parent_idx = game_dict_keys_lower.index(found_parent_name_lower)
+                final_parent_name = game_dict_keys[final_parent_idx]
 
             priority = get_priority(dupe_dict=dupes, parent_name=found_parent_name, game_name=g)
 
-            game_dict[found_parent_name][g] = {"priority": priority}
+            game_dict[final_parent_name][g] = {"priority": priority}
 
         return game_dict

--- a/romsearch/modules/romchooser.py
+++ b/romsearch/modules/romchooser.py
@@ -197,11 +197,16 @@ def remove_unwanted_roms(rom_dict, key_to_check, check_type="include"):
 def get_best_roms(files, rom_dict):
     """Get the best ROM(s) from a list, using a scoring system"""
 
+    # Positive scores
     improved_version_score = 1
+    version_score = 10
+    revision_score = 100
+    budget_edition_score = 1000
+
+    # Negative scores
     demoted_version_score = -1
     alternate_version_score = -1
     modern_version_score = -10
-    version_score = 100
     priority_score = -100
 
     file_scores = np.zeros(len(files))
@@ -209,10 +214,12 @@ def get_best_roms(files, rom_dict):
     # Improved or demoted versions
     file_scores += improved_version_score * np.array([int(rom_dict[f]["improved_version"]) for f in files])
     file_scores += demoted_version_score * np.array([int(rom_dict[f]["demoted_version"]) for f in files])
+    file_scores += budget_edition_score * np.array([int(rom_dict[f]["budget_edition"]) for f in files])
     file_scores += alternate_version_score * np.array([int(rom_dict[f]["alternate"]) for f in files])
 
     # Version numbering, which needs to be parsed
     file_scores += version_score * add_versioned_score(files, rom_dict, "version")
+    file_scores += revision_score * add_versioned_score(files, rom_dict, "revision")
 
     # Downweight modern versions
     file_scores += modern_version_score * np.array([int(rom_dict[f]["modern_version"]) for f in files])
@@ -425,6 +432,7 @@ class ROMChooser:
             self.logger.debug("Getting best version")
             rom_dict = get_best_version(rom_dict)
             rom_dict = remove_unwanted_roms(rom_dict, key_to_check="improved_versions", check_type="include")
+            rom_dict = remove_unwanted_roms(rom_dict, key_to_check="budget_edition", check_type="include")
             rom_dict = remove_unwanted_roms(rom_dict, key_to_check="demoted_versions", check_type="exclude")
             rom_dict = remove_unwanted_roms(rom_dict, key_to_check="modern_versions", check_type="exclude")
             rom_dict = remove_unwanted_roms(rom_dict, key_to_check="alternate", check_type="exclude")


### PR DESCRIPTION
- Grouped ``rerelease`` with ``demoted_versions`` in regex
- Decoupled revisions from versions
- Revisions are now weighted more heavily than versions
- Budget editions are now favoured above anything else, assuming they roll in the various revision/version changes
- Fixed bug in GameFinder where occasionally multiple entries due to upper/lowercase could occur