### PR TITLE
ROMSearch method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,26 @@
 0.0.5 (Unreleased)
 ==================
 
+Features
+--------
+
+- ROMSearch now has two modes: the first is `filter_then_download` (default), which will use the dat file to filter,
+  then only download relevant files. The second is `download_then_filter`, which will download everything and then
+  filter. For data hoarders!
+
 Fixes
 -----
+
+GameFinder
+~~~~~~~~~~
+
+- Ensure includes/excludes works the same as it does for ROMDownloader
+- Includes/excludes will now search dupes as well, for consistency
+
+ROMDownloader
+~~~~~~~~~~~~~
+
+- Ensure output directory exists before downloading files
 
 General
 ~~~~~~~

--- a/docs/configs/config.rst
+++ b/docs/configs/config.rst
@@ -4,6 +4,9 @@ config
 
 The ``config.yml`` file defines how ROMSearch will do the run. As such, it has quite a number of options.
 
+As a note on includes, this will match something from the start of the string. So "Game Title VII" would include
+"Game Title VII", "Game Title VIII", but not "Game Title Anthology - Game Title VII", for example.
+
 Syntax: ::
 
     dirs:
@@ -31,6 +34,8 @@ Syntax: ::
         - [game]
 
     romsearch:                          # ROMSearch specific options
+      method: 'filter_then_download'    # OPTIONAL. Method to use, option are 'filter_then_download', or
+                                        #           'download_then_filter'. Defaults to 'filter_then_download'
       run_romdownloader: true           # OPTIONAL. Whether to run ROMDownloader. Defaults to true
       run_datparser: true               # OPTIONAL. Whether to run DATParser. Defaults to true
       run_dupeparser: true              # OPTIONAL. Whether to run DupeParsed. Defaults to true
@@ -58,15 +63,15 @@ Syntax: ::
     romchooser:                         # ROMChooser specific options
       dry_run: false                    # OPTIONAL. Set to true to not make any changes to filesystem. Defaults to false
       use_best_version: true            # OPTIONAL. Whether to choose only what ROMChooser decides is the best version.
-                                                    Defaults to true
+                                        #           Defaults to true
       allow_multiple_regions: false     # OPTIONAL. If true, will allow files from multiple regions, else will choose the
-                                                    highest region in the list. Defaults to false
+                                        #           highest region in the list. Defaults to false
       filter_regions: true              # OPTIONAL. Whether to filter by region or not. Defaults to true
       filter_languages: true            # OPTIONAL. Whether to filter by language or not. Defaults to true
       bool_filters: "all_but_games"     # OPTIONAL. Can filter out non-games by various dat categories. If you want to
-                                                    include e.g. just games and applications, set to
-                                                    ['games', 'applications']. Defaults to 'all_but_games', which will
-                                                    remove everything except games
+                                        #           include e.g. just games and applications, set to
+                                        #           ['games', 'applications']. Defaults to 'all_but_games', which will
+                                        #           remove everything except games
 
     discord:                            # OPTIONAL. If defined, supply a webhook URL so that ROMSearch can post Discord
       webhook_url: [webhook_url]        #           notifications

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -27,6 +27,11 @@ ROMSearch offers the ability to:
 To get started, see the :doc:`installation <installation>` and :doc:`configuration <configuration>` pages. For the
 philosophy behind how ROMSearch chooses a ROM, see :doc:`1G1R <1g1r>`.
 
+ROMSearch offers two modes: the default is "filter, then download" which will use the .dat file to find the best ROMs
+and only download those. For data hoarders, we also offer a "download, then filter" option, which will download
+everything and then filter from the downloaded files. For more details, see the
+:doc:`ROMSearch module docs <modules/romsearch>`.
+
 Currently, ROMSearch is in early development, and so many features may be added over time. At the moment, ROMSearch
 has the capability for:
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -2,6 +2,10 @@
 Known Issues
 ############
 
+* In GameFinder, includes/excludes can cause some unexpected behavior since it will also search through duplicate files.
+  For example, having an include of "Crash Bandicoot" for the PS1 will also grab "Crash Bash" and
+  "CTR - Crash Team Racing" since at least one of their duplicates starts with "Crash Bandicoot".
+
 * Currently, the code is not aware of ``retool``'s supersets or compilations array.
 
 * Occasionally, multiple ROMs will be found with the same priority.

--- a/docs/modules/romsearch.rst
+++ b/docs/modules/romsearch.rst
@@ -5,6 +5,10 @@ ROMSearch
 This is the main part that controls the various other modules. It essentially calls everything (given user preferences),
 and so while it doesn't really do all that much on its own, is the interface to everything else.
 
+ROMSearch has 2 modes, the default will parse from the .dat file then download relevant files, to minimize disc space
+used (`filter_then_download`). For completionists/data hoarders, there's also a `download_then_filter` option, which
+will download and then filter from the downloaded files.
+
 For more details on the ROMSearch arguments, see the :doc:`config file documentation <../configs/config>`.
 
 API

--- a/romsearch/configs/sample_config.yml
+++ b/romsearch/configs/sample_config.yml
@@ -21,6 +21,7 @@ include_games:
     - "Chrono Trigger"
 
 romsearch:
+  method: "filter_then_download"
   run_romdownloader: true
   run_datparser: true
   run_dupeparser: true

--- a/romsearch/modules/romparser.py
+++ b/romsearch/modules/romparser.py
@@ -1,12 +1,10 @@
 import copy
 import os
 import re
-import time
-from datetime import datetime
 
 import romsearch
 from ..util import (setup_logger,
-
+                    get_file_time,
                     load_yml,
                     load_json,
                     get_game_name,
@@ -68,21 +66,6 @@ def get_pattern_val(regex,
         pattern_val = None
 
     return pattern_val
-
-
-def get_file_time(f,
-                  datetime_format,
-                  ):
-    """Get created file time from the file itself"""
-
-    if os.path.exists(f):
-        ti_m = os.path.getmtime(f)
-        date_ti_m = datetime.strptime(time.ctime(ti_m), "%a %b %d %H:%M:%S %Y")
-    else:
-        date_ti_m = datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0)
-    date_ti_m_str = date_ti_m.strftime(format=datetime_format)
-
-    return date_ti_m_str
 
 
 class ROMParser:

--- a/romsearch/util/__init__.py
+++ b/romsearch/util/__init__.py
@@ -1,5 +1,5 @@
 from .discord import discord_push
-from .general import split, get_parent_name
+from .general import split, get_parent_name, get_file_time
 from .io import load_yml, unzip_file, load_json, save_json
 from .logger import setup_logger
 from .regex_matching import get_file_pattern, get_bracketed_file_pattern, get_game_name, get_short_name
@@ -17,4 +17,5 @@ __all__ = [
     "discord_push",
     "split",
     "get_parent_name",
+    "get_file_time",
 ]

--- a/romsearch/util/general.py
+++ b/romsearch/util/general.py
@@ -1,4 +1,8 @@
 import copy
+import os
+import time
+from datetime import datetime
+
 
 def split(full_list, chunk_size=10):
     """Split a list in chunks of size chunk_size
@@ -53,3 +57,18 @@ def get_parent_name(game_name,
         raise ValueError("Could not find a parent name!")
 
     return found_parent_name
+
+
+def get_file_time(f,
+                  datetime_format,
+                  ):
+    """Get created file time from the file itself"""
+
+    if os.path.exists(f):
+        ti_m = os.path.getmtime(f)
+        date_ti_m = datetime.strptime(time.ctime(ti_m), "%a %b %d %H:%M:%S %Y")
+    else:
+        date_ti_m = datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0)
+    date_ti_m_str = date_ti_m.strftime(format=datetime_format)
+
+    return date_ti_m_str


### PR DESCRIPTION
- ROMSearch now has two modes: the first is `filter_then_download` (default), which will use the dat file to filter,
  then only download relevant files. The second is `download_then_filter`, which will download everything and then
  filter. For data hoarders!
- Ensure includes/excludes works the same as it does for ROMDownloader in GameFinder
- Includes/excludes will now search dupes as well in GameFinder, for consistency
- Ensure output directory exists before downloading files
