### PR TITLE
Significant speedup in romparser.py by being smarter with RA handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ ROMMover
 ROMParser
 ~~~~~~~~~
 
+- Significant speedup by being smarter with RA handling
 - Ensure we sanitize versions for checking RetroAchievement hashes
 
 ROMPatcher

--- a/romsearch/modules/gamefinder.py
+++ b/romsearch/modules/gamefinder.py
@@ -669,16 +669,23 @@ class GameFinder:
             dupe_entry: Dictionary of game properties
             filters: Filters with conditions and results to apply
         """
-
         # Parse out the filename
         file_to_parse = {game_name["full_name"]: game_name}
+
+        # Don't use RA hashes here
+        rp_config = copy.deepcopy(self.config)
+        if "romparser" not in rp_config:
+            rp_config["romparser"] = {}
+        rp_config["romparser"]["use_ra_hashes"] = False
+
         rp = ROMParser(
             platform=self.platform,
             game=parent_name,
-            config=self.config,
             dat=self.dat,
             retool=self.retool,
             ra_hashes=self.ra_hashes,
+            config=rp_config,
+            platform_config=self.platform_config,
             default_config=self.default_config,
             regex_config=self.regex_config,
             logger=self.logger,

--- a/romsearch/modules/romsearch.py
+++ b/romsearch/modules/romsearch.py
@@ -606,8 +606,8 @@ class ROMSearch:
             ra_hashes=ra_hash,
             config=self.config,
             platform_config=platform_config,
-            regex_config=self.regex_config,
             default_config=self.default_config,
+            regex_config=self.regex_config,
             logger=self.logger,
             log_line_length=log_line_length,
         )


### PR DESCRIPTION
- GameFinder now parses without RA hashes
- GameFinder now passes platform config to ROMParser for less I/O
- ROMParser will now only read in the RA dictionary once
- ROMParser will now only parse each RA entry once
