### PR TITLE
RA Parsing fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ ROMMover
 ROMParser
 ~~~~~~~~~
 
+- Fix bug where if we're not looking for RA entries with patches, we'd still look for them
+- Fix bug where games from the same region with similar languages could mistakenly be assigned
+  as having RetroAchievements
 - Significant speedup by being smarter with RA handling
 - Ensure we sanitize versions for checking RetroAchievement hashes
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -13,7 +13,4 @@ Known Issues
 
 * Currently, the code only handles ``retool``'s compilations to a very limited degree.
 
-* Sometimes certain RA listings may not be properly found -- one example of this is the USA version of Super Mario
-  Sunshine. This is because the RA listing has an old name for the ROM.
-
 * Occasionally, multiple ROMs can be found with the same priority.

--- a/romsearch/configs/defaults.yml
+++ b/romsearch/configs/defaults.yml
@@ -288,6 +288,7 @@ ra_labels:
 
 ra_patch_checks:
   - "regions"
+  - "languages"
   - "version_no"
   - "revision"
   - "multi_disc"

--- a/romsearch/modules/romparser.py
+++ b/romsearch/modules/romparser.py
@@ -145,14 +145,23 @@ def check_match(i, j, checks_passed=None):
         if not i == j:
             checks_passed = False
 
-    # If a list, then check there's at least some overlap
+    # If a list, treat differently
     elif isinstance(i, list):
         s_i = set(i)
         s_j = set(j)
         s_k = s_i.intersection(s_j)
 
-        if len(s_k) == 0:
+        # Only fail on a 0-length intersection if at least one of the inputs has
+        # non-zero length
+        if len(s_k) == 0 and len(s_i) > 0 and len(s_j) > 0:
             checks_passed = False
+
+        # If we have the case where both entries have more than 1 item, then ensure
+        # they *all* match in at least one of the lists
+        if len(s_i) > 1 and len(s_j) > 1:
+            min_n_match = min(len(s_i), len(s_j))
+            if len(s_k) < min_n_match:
+                checks_passed = False
 
     else:
         t = type(i)
@@ -858,6 +867,11 @@ class ROMParser:
 
             # If we want patch files, and we don't have them, skip
             if want_patched_files and self.ra_dict[r]["patch_url"] is None:
+                continue
+
+            # Conversely, if we don't want patch files, and we do have them,
+            # skip
+            if not want_patched_files and self.ra_dict[r]["patch_url"] is not None:
                 continue
 
             if multiple_patch_files_found:


### PR DESCRIPTION
- Fix bug where games from the same region with similar languages could mistakenly be assigned as having RetroAchievements
- If we're not looking for patched files, then don't look for them
