### PR TITLE
Better handle compilations/supersets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ ROMDownloader
 ROMMover
 ~~~~~~~~
 
+- If a particular ROM is a superset or compilation, then change the output
+  directory to reflect that
 - Ensure subchannel files are also moved
 - Include info on how many files have been moved
 - Save cache each time a ROM is moved, in case of interruption

--- a/docs/1g1r.rst
+++ b/docs/1g1r.rst
@@ -62,6 +62,13 @@ the user. Secondly, supersets are prioritised over everything **except** ROMs th
 RetroAchievements. This will mean that you may get a ROM from a different region than you might expect, but if it
 doesn't have RetroAchievements then this will be below a ROM that does.
 
+A note on compilations/supersets
+---------------------------------
+
+In the case of compilations and supersets, these can be non-unique to a game (e.g. a compilation of multiple games,
+or a superset containing a number of DLC). To avoid duplicating ROMs, if a compilation or superset is chosen then
+this ends up in a directory based on the short name of the ROM, rather than the overarching game name.
+
 End result
 ----------
 

--- a/romsearch/modules/rommover.py
+++ b/romsearch/modules/rommover.py
@@ -7,6 +7,7 @@ import romsearch
 from .romcompressor import ROMCompressor
 from .rompatcher import ROMPatcher
 from ..util import (
+    get_directory_name,
     centred_string,
     load_yml,
     setup_logger,
@@ -206,10 +207,23 @@ class ROMMover:
             for rom_no, rom in enumerate(rom_dict):
 
                 # Because the filename can change, keep it here
-                rom_file = rom_dict[rom]["download_name"]
+                full_name = copy.deepcopy(rom_dict[rom]["full_name"])
+                rom_file = copy.deepcopy(rom_dict[rom]["download_name"])
+                short_name = copy.deepcopy(rom_dict[rom]["short_name"])
 
-                # Pull out a clean directory name, and disc-free name in case we need it
-                dir_name = str(copy.deepcopy(rom_dict[rom]["dir_name"]))
+                # If we're either a superset or a compilation, then
+                # inherit a game and directory name from the ROM
+                # instead. This will avoid multiple downloads in
+                # some circumstances
+                is_superset = rom_dict[rom].get("is_superset", False)
+                is_compilation = rom_dict[rom].get("is_compilation", False)
+
+                if is_superset or is_compilation:
+                    dir_name = get_directory_name(full_name)
+                    game = copy.deepcopy(short_name)
+                else:
+                    # Pull out a clean directory name and disc-free name in case we need it
+                    dir_name = str(copy.deepcopy(rom_dict[rom]["dir_name"]))
                 disc_free_name = str(copy.deepcopy(rom_dict[rom]["disc_free_name"]))
 
                 cache_mod_time = (


### PR DESCRIPTION
- For compilations and supersets, move into a directory based on short name. Avoids multiple ROMs hanging around
