### PR TITLE
ROMMover Tab Added with ES friendly folder naming structure

### DIFF
--- a/romsearch/configs/platforms/Nintendo - Game Boy Advance.yml
+++ b/romsearch/configs/platforms/Nintendo - Game Boy Advance.yml
@@ -12,3 +12,6 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+
+#EmulationStation Friendly Name
+es_friendly_name: "gba"

--- a/romsearch/configs/platforms/Nintendo - Game Boy Color.yml
+++ b/romsearch/configs/platforms/Nintendo - Game Boy Color.yml
@@ -12,3 +12,5 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+#EmulationStation Friendly Name
+es_friendly_name: "gbc"

--- a/romsearch/configs/platforms/Nintendo - Game Boy.yml
+++ b/romsearch/configs/platforms/Nintendo - Game Boy.yml
@@ -12,3 +12,5 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+#EmulationStation Friendly Name
+es_friendly_name: "gb"

--- a/romsearch/configs/platforms/Nintendo - GameCube.yml
+++ b/romsearch/configs/platforms/Nintendo - GameCube.yml
@@ -7,3 +7,5 @@ file_exts:
 # RetroAchievements
 ra_id: 16
 ra_hash_method: "custom"
+#EmulationStation Friendly Name
+es_friendly_name: "gc"

--- a/romsearch/configs/platforms/Nintendo - Nintendo 64.yml
+++ b/romsearch/configs/platforms/Nintendo - Nintendo 64.yml
@@ -12,3 +12,6 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+
+#EmulationStation Friendly Name
+es_friendly_name: "n64"

--- a/romsearch/configs/platforms/Nintendo - Nintendo DS.yml
+++ b/romsearch/configs/platforms/Nintendo - Nintendo DS.yml
@@ -12,3 +12,6 @@ ra_hash_method: "custom"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+
+#EmulationStation Friendly Name
+es_friendly_name: "nds"

--- a/romsearch/configs/platforms/Nintendo - Nintendo Entertainment System.yml
+++ b/romsearch/configs/platforms/Nintendo - Nintendo Entertainment System.yml
@@ -12,3 +12,6 @@ ra_hash_method: "custom"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".ips"
+
+#EmulationStation Friendly Name
+es_friendly_name: "nes"

--- a/romsearch/configs/platforms/Nintendo - Pokemon Mini.yml
+++ b/romsearch/configs/platforms/Nintendo - Pokemon Mini.yml
@@ -7,3 +7,6 @@ file_exts:
 # RetroAchievements
 ra_id: 24
 ra_hash_method: "md5"
+
+#EmulationStation Friendly Name
+es_friendly_name: "pm"

--- a/romsearch/configs/platforms/Nintendo - Super Nintendo Entertainment System.yml
+++ b/romsearch/configs/platforms/Nintendo - Super Nintendo Entertainment System.yml
@@ -12,3 +12,6 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+
+#EmulationStation Friendly Name
+es_friendly_name: "snes"

--- a/romsearch/configs/platforms/Nintendo - Virtual Boy.yml
+++ b/romsearch/configs/platforms/Nintendo - Virtual Boy.yml
@@ -7,3 +7,6 @@ file_exts:
 # RetroAchievements
 ra_id: 28
 ra_hash_method: "md5"
+
+#EmulationStation Friendly Name
+es_friendly_name: "vb"

--- a/romsearch/configs/platforms/Sega - Game Gear.yml
+++ b/romsearch/configs/platforms/Sega - Game Gear.yml
@@ -12,3 +12,6 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+
+#EmulationStation Friendly Name
+es_friendly_name: "gg"

--- a/romsearch/configs/platforms/Sega - Mega Drive - Genesis.yml
+++ b/romsearch/configs/platforms/Sega - Mega Drive - Genesis.yml
@@ -12,3 +12,6 @@ ra_hash_method: "md5"
 patch_method: "rompatcher.js"
 patch_file_exts:
   - ".bps"
+
+#EmulationStation Friendly Name
+es_friendly_name: "md"

--- a/romsearch/configs/platforms/Sony - PlayStation 2.yml
+++ b/romsearch/configs/platforms/Sony - PlayStation 2.yml
@@ -18,3 +18,6 @@ ra_hash_method: "custom"
 patch_method: "xdelta"
 patch_file_exts:
   - ".xdelta"
+
+#EmulationStation Friendly Name
+es_friendly_name: "ps2"

--- a/romsearch/configs/platforms/Sony - PlayStation Portable.yml
+++ b/romsearch/configs/platforms/Sony - PlayStation Portable.yml
@@ -12,3 +12,6 @@ ra_hash_method: "custom"
 patch_method: "xdelta"
 patch_file_exts:
   - ".xdelta"
+
+#EmulationStation Friendly Name
+es_friendly_name: "psp"

--- a/romsearch/configs/platforms/Sony - PlayStation.yml
+++ b/romsearch/configs/platforms/Sony - PlayStation.yml
@@ -15,3 +15,6 @@ subchannels:
 # RetroAchievements
 ra_id: 12
 ra_hash_method: "custom"
+
+#EmulationStation Friendly Name
+es_friendly_name: "ps"

--- a/romsearch/gui/gui_config.py
+++ b/romsearch/gui/gui_config.py
@@ -258,6 +258,10 @@ class ConfigWindow(QMainWindow):
             "dry_run": self.ui.checkBoxConfigRomChooserDryRun,
         }
 
+        self.all_rommover_options = {
+            "es_friendly_name": self.ui.checkBoxConfigRomMoverESFriendlyFolders,
+        }
+
         self.all_dat_filters = {
             "add-ons": self.ui.checkBoxConfigRomChooserDatFiltersAddons,
             "applications": self.ui.checkBoxConfigRomChooserDatFiltersApplications,
@@ -520,6 +524,7 @@ class ConfigWindow(QMainWindow):
             "gamefinder": self.all_gamefinder_options,
             "romparser": self.all_romparser_options,
             "romchooser": self.all_romchooser_options,
+            "rommover": self.all_rommover_options
         }
 
         # Set all the various tabs
@@ -719,6 +724,7 @@ class ConfigWindow(QMainWindow):
             "gamefinder": self.all_gamefinder_options,
             "romparser": self.all_romparser_options,
             "romchooser": self.all_romchooser_options,
+            "rommover": self.all_rommover_options
         }
 
         # Module options. Checkboxes first

--- a/romsearch/gui/layout_romsearch.py
+++ b/romsearch/gui/layout_romsearch.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'layout_romsearch.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.0
+## Created by: Qt User Interface Compiler version 6.9.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -1339,6 +1339,35 @@ class Ui_RomSearch(object):
         self.horizontalLayout_11.addLayout(self.gridLayoutConfigRomChooser)
 
         self.tabWidgetConfig.addTab(self.tabConfigRomChooser, "")
+        self.tabConfigRomMover = QWidget()
+        self.tabConfigRomMover.setObjectName(u"tabConfigRomMover")
+        self.tabConfigRomMover.setEnabled(True)
+        self.gridLayout_5 = QGridLayout(self.tabConfigRomMover)
+        self.gridLayout_5.setObjectName(u"gridLayout_5")
+        self.gridLayout_4 = QGridLayout()
+        self.gridLayout_4.setObjectName(u"gridLayout_4")
+        self.gridLayoutConfigRomDownloaderRight_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_4.addItem(self.gridLayoutConfigRomDownloaderRight_2, 0, 2, 1, 1)
+
+        self.verticalLayout_6 = QVBoxLayout()
+        self.verticalLayout_6.setObjectName(u"verticalLayout_6")
+        self.checkBoxConfigRomMoverESFriendlyFolders = QCheckBox(self.tabConfigRomMover)
+        self.checkBoxConfigRomMoverESFriendlyFolders.setObjectName(u"checkBoxConfigRomMoverESFriendlyFolders")
+
+        self.verticalLayout_6.addWidget(self.checkBoxConfigRomMoverESFriendlyFolders)
+
+
+        self.gridLayout_4.addLayout(self.verticalLayout_6, 0, 1, 1, 1)
+
+        self.gridLayoutConfigRomDownloaderLeft_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_4.addItem(self.gridLayoutConfigRomDownloaderLeft_2, 0, 0, 1, 1)
+
+
+        self.gridLayout_5.addLayout(self.gridLayout_4, 0, 0, 1, 1)
+
+        self.tabWidgetConfig.addTab(self.tabConfigRomMover, "")
         self.tabConfigRomPatcher = QWidget()
         self.tabConfigRomPatcher.setObjectName(u"tabConfigRomPatcher")
         self.verticalLayout_4 = QVBoxLayout(self.tabConfigRomPatcher)
@@ -1760,7 +1789,7 @@ class Ui_RomSearch(object):
         RomSearch.setCentralWidget(self.centralwidget)
         self.menubar = QMenuBar(RomSearch)
         self.menubar.setObjectName(u"menubar")
-        self.menubar.setGeometry(QRect(0, 0, 1298, 33))
+        self.menubar.setGeometry(QRect(0, 0, 1298, 21))
         self.menuFile = QMenu(self.menubar)
         self.menuFile.setObjectName(u"menuFile")
         self.menuHelp = QMenu(self.menubar)
@@ -1784,7 +1813,7 @@ class Ui_RomSearch(object):
         self.retranslateUi(RomSearch)
 
         self.tabWidgetModules.setCurrentIndex(0)
-        self.tabWidgetConfig.setCurrentIndex(0)
+        self.tabWidgetConfig.setCurrentIndex(4)
 
 
         QMetaObject.connectSlotsByName(RomSearch)
@@ -2121,6 +2150,8 @@ class Ui_RomSearch(object):
         self.checkBoxConfigRomChooserDatFiltersUnlicensed.setText(QCoreApplication.translate("RomSearch", u"Unlicensed", None))
         self.checkBoxConfigRomChooserDatFiltersVideo.setText(QCoreApplication.translate("RomSearch", u"Video", None))
         self.tabWidgetConfig.setTabText(self.tabWidgetConfig.indexOf(self.tabConfigRomChooser), QCoreApplication.translate("RomSearch", u"ROMChooser", None))
+        self.checkBoxConfigRomMoverESFriendlyFolders.setText(QCoreApplication.translate("RomSearch", u"Emulation Station friendly names?", None))
+        self.tabWidgetConfig.setTabText(self.tabWidgetConfig.indexOf(self.tabConfigRomMover), QCoreApplication.translate("RomSearch", u"ROMMover", None))
         self.labelConfigRomPatcherxdelta.setText(QCoreApplication.translate("RomSearch", u"xdelta path", None))
         self.lineEditConfigRomPatcherxdeltaPath.setPlaceholderText(QCoreApplication.translate("RomSearch", u"xdelta.exe", None))
         self.pushButtonConfigRomPatcherxdeltaPath.setText(QCoreApplication.translate("RomSearch", u"Browse", None))

--- a/romsearch/gui/layout_romsearch.ui
+++ b/romsearch/gui/layout_romsearch.ui
@@ -52,7 +52,7 @@
            <enum>QTabWidget::TabShape::Rounded</enum>
           </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>10</number>
           </property>
           <property name="tabsClosable">
            <bool>false</bool>
@@ -2345,6 +2345,57 @@
             </item>
            </layout>
           </widget>
+          <widget class="QWidget" name="tabConfigRomMover">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <attribute name="title">
+            <string>ROMMover</string>
+           </attribute>
+           <layout class="QGridLayout" name="gridLayout_5">
+            <item row="0" column="0">
+             <layout class="QGridLayout" name="gridLayout_4">
+              <item row="0" column="2">
+               <spacer name="gridLayoutConfigRomDownloaderRight_2">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="1">
+               <layout class="QVBoxLayout" name="verticalLayout_6">
+                <item>
+                 <widget class="QCheckBox" name="checkBoxConfigRomMoverESFriendlyFolders">
+                  <property name="text">
+                   <string>Emulation Station friendly folder names? (i.e. Nintendo - Game Boy &gt; gb, Sony - Playstation 1 &gt; psx etc.)</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="0">
+               <spacer name="gridLayoutConfigRomDownloaderLeft_2">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
           <widget class="QWidget" name="tabConfigRomPatcher">
            <attribute name="title">
             <string>ROMPatcher</string>
@@ -3084,7 +3135,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
      <x>0</x>
      <y>0</y>
      <width>1298</width>
-     <height>33</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -3175,7 +3226,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="radioButtonConfigLoggerLevel"/>
   <buttongroup name="radioButtonConfigRomsearchMethod"/>
+  <buttongroup name="radioButtonConfigLoggerLevel"/>
  </buttongroups>
 </ui>

--- a/romsearch/modules/rommover.py
+++ b/romsearch/modules/rommover.py
@@ -394,11 +394,19 @@ class ROMMover:
 
                 # Keep track of absolute directories and relative directories to the
                 # platform itself, for cache reasons
+                
+                # Decide whether to use platform name or ES-friendly name
+                if self.config.get("use_es_friendly_name", True) and self.platform_config.get("es_friendly_name") is not None:
+                    base_dir = self.platform_config.get("es_friendly_name")
+                else:
+                    base_dir = self.platform
+
+                # Build output path
                 if self.separate_directories:
-                    out_dir = os.path.join(self.rom_dir, self.platform, dir_name)
+                    out_dir = os.path.join(self.rom_dir, base_dir, dir_name)
                     out_base_dir = copy.deepcopy(dir_name)
                 else:
-                    out_dir = os.path.join(self.rom_dir, self.platform)
+                    out_dir = os.path.join(self.rom_dir, base_dir)
                     out_base_dir = ""
 
                 # Skip if the file modification time matches the one in the cache, we're not patching, and the


### PR DESCRIPTION
- Added option to enable EmulationStation friendly folder names so that ROMMover can automatically move them to the correct folder if you use emulationstation for your roms.
- Updated platform config files with ES friendly name